### PR TITLE
doc usage of client-certificate for rest-sensor

### DIFF
--- a/source/_integrations/rest.markdown
+++ b/source/_integrations/rest.markdown
@@ -113,6 +113,11 @@ force_update:
   reqired: false
   type: boolean
   default: false
+file_path:
+  description: Path to the file that contains the client-certificate used for authentication. Make sure the file contains private key ant the certificate
+  required: false
+  type: string
+  
 {% endconfiguration %}
 
 <div class='note warning'>


### PR DESCRIPTION
**Description:**


**Pull request in home-assistant (if applicable):** home-assistant/home-assistant#<home-assistant PR number goes here>

## Checklist:

- [x] Branch: `next` is for changes and new documentation that will go public with the next Home Assistant release. Fixes, changes and adjustments for the current release should be created against `current`.
- [x] The documentation follows the [standards][standards].

[standards]: https://developers.home-assistant.io/docs/documentation_standards.html
